### PR TITLE
fix: placeholder spacing and unsatisfiable constraints during introspection

### DIFF
--- a/sqg/src/db/duckdb.ts
+++ b/sqg/src/db/duckdb.ts
@@ -12,7 +12,13 @@ import { DatabaseError, SqlExecutionError } from "../errors.js";
 import type { SQLQuery, TableInfo } from "../sql-query.js";
 import { type ColumnType, EnumType, ListType, MapType, StructType } from "../sql-query.js";
 import type { ProgressReporter } from "../ui.js";
-import { type DatabaseEngine, type InitDatabaseOptions, initializeDatabase } from "./types.js";
+import {
+  type DatabaseEngine,
+  type InitDatabaseOptions,
+  initializeDatabase,
+  isConstraintViolation,
+  warnConstraintViolation,
+} from "./types.js";
 
 /** Cache of enum type names, keyed by stringified sorted values for lookup */
 let enumNameCache = new Map<string, string>();
@@ -216,6 +222,10 @@ export const duckdb = new (class implements DatabaseEngine {
       }
       return await stmt.run();
     } catch (error) {
+      if (!query.isQuery && isConstraintViolation(error)) {
+        warnConstraintViolation(query, error);
+        return;
+      }
       consola.error(`Failed to execute query '${query.id}':`, error);
       throw error;
     }

--- a/sqg/src/db/postgres.ts
+++ b/sqg/src/db/postgres.ts
@@ -6,7 +6,12 @@ import { DatabaseError, SqlExecutionError } from "../errors.js";
 import type { SQLQuery, TableInfo } from "../sql-query.js";
 import { type ColumnType, EnumType } from "../sql-query.js";
 import type { ProgressReporter } from "../ui.js";
-import { type DatabaseEngine, initializeDatabase } from "./types.js";
+import {
+  type DatabaseEngine,
+  initializeDatabase,
+  isConstraintViolation,
+  warnConstraintViolation,
+} from "./types.js";
 
 const tempDatabaseName = "sqg-db-temp";
 
@@ -25,8 +30,48 @@ interface ConnectionMode {
   connect(): Promise<Client>;
   /** Wrap a query execution so side effects are isolated. */
   wrapQuery(db: Client, fn: () => Promise<QueryResult>): Promise<QueryResult>;
+  /** Stop enforcing referential integrity, see {@link relaxConstraints}. */
+  relaxConstraints(db: Client): Promise<void>;
   /** Clean up connections. */
   close(db: Client): Promise<void>;
+}
+
+/**
+ * Turn off referential integrity enforcement for the introspection connection.
+ *
+ * QUERY and EXEC statements are introspected against whatever data MIGRATE and
+ * TESTDATA left behind, each in its own transaction, so a NOT NULL foreign key
+ * can never be satisfied by a row an earlier statement inserted.
+ * `session_replication_role = replica` disables the triggers enforcing it, for
+ * this connection only, and every statement introspected here is rolled back.
+ *
+ * This happens after the database is initialized, so a foreign key violation in
+ * a MIGRATE or TESTDATA block is still reported — those describe real data.
+ *
+ * Setting it needs superuser (or the SET privilege), so this is best effort:
+ * without it, constraint violations on EXEC statements are still tolerated,
+ * only INSERT ... RETURNING queries would fail.
+ */
+async function relaxConstraints(db: Client, inTransaction: boolean): Promise<void> {
+  try {
+    if (inTransaction) {
+      // A failed SET would poison the surrounding transaction, so shield it.
+      await db.query("SAVEPOINT sqg_relax_constraints");
+      try {
+        await db.query("SET LOCAL session_replication_role = 'replica'");
+      } catch (e) {
+        await db.query("ROLLBACK TO SAVEPOINT sqg_relax_constraints");
+        throw e;
+      }
+      await db.query("RELEASE SAVEPOINT sqg_relax_constraints");
+    } else {
+      await db.query("SET session_replication_role = 'replica'");
+    }
+  } catch (e) {
+    consola.debug(
+      `Could not disable constraint enforcement for introspection: ${(e as Error).message}`,
+    );
+  }
 }
 
 /**
@@ -62,6 +107,13 @@ class ExternalDbMode implements ConnectionMode {
     } finally {
       await db.query("ROLLBACK TO SAVEPOINT sqg_query");
     }
+  }
+
+  relaxConstraints(db: Client): Promise<void> {
+    // Inside the outer transaction, so SET LOCAL — it survives the per-query
+    // savepoints (which only undo what happens after them) and is reverted by
+    // the ROLLBACK in close().
+    return relaxConstraints(db, true);
   }
 
   async close(db: Client): Promise<void> {
@@ -137,6 +189,10 @@ class TempDbMode implements ConnectionMode {
     } finally {
       await db.query("ROLLBACK");
     }
+  }
+
+  relaxConstraints(db: Client): Promise<void> {
+    return relaxConstraints(db, false);
   }
 
   async close(db: Client): Promise<void> {
@@ -290,6 +346,9 @@ export const postgres = new (class implements DatabaseEngine {
         "This is an internal error. Check that migrations completed successfully.",
       );
     }
+    // Only now that MIGRATE and TESTDATA have run — those still get their
+    // foreign keys checked.
+    await this.mode.relaxConstraints(db);
     try {
       const executableQueries = queries.filter((q) => !q.skipGenerateFunction);
 
@@ -384,6 +443,10 @@ export const postgres = new (class implements DatabaseEngine {
       }
       return result;
     } catch (error) {
+      if (!query.isQuery && isConstraintViolation(error)) {
+        warnConstraintViolation(query, error);
+        return;
+      }
       consola.error(`Failed to execute query '${query.id}':`, error);
       throw error;
     }

--- a/sqg/src/db/sqlite.ts
+++ b/sqg/src/db/sqlite.ts
@@ -4,7 +4,12 @@ import { isNotNil } from "es-toolkit";
 import { DatabaseError, SqlExecutionError } from "../errors.js";
 import type { SQLQuery, TableInfo } from "../sql-query.js";
 import type { ProgressReporter } from "../ui.js";
-import { type DatabaseEngine, initializeDatabase } from "./types.js";
+import {
+  type DatabaseEngine,
+  initializeDatabase,
+  isConstraintViolation,
+  warnConstraintViolation,
+} from "./types.js";
 
 export const sqlite = new (class implements DatabaseEngine {
   db!: Database;
@@ -43,6 +48,13 @@ export const sqlite = new (class implements DatabaseEngine {
         "This is an internal error. Migrations may have failed silently.",
       );
     }
+    // better-sqlite3 turns foreign keys ON by default. QUERY and EXEC blocks are
+    // introspected against whatever MIGRATE and TESTDATA left behind, so an
+    // INSERT referencing a row that no fixture created cannot satisfy them.
+    // Enforcement stays on while the database is initialized above, so a broken
+    // foreign key in a MIGRATE or TESTDATA block is still an error.
+    db.pragma("foreign_keys = OFF");
+
     try {
       // Skip the setup query as it's already executed
       const executableQueries = queries.filter((q) => !q.skipGenerateFunction);
@@ -204,6 +216,10 @@ export const sqlite = new (class implements DatabaseEngine {
       }
       return stmt.run(...params);
     } catch (error) {
+      if (!query.isQuery && isConstraintViolation(error)) {
+        warnConstraintViolation(query, error);
+        return;
+      }
       consola.error(
         `Failed to execute query '${query.id}' in ${query.filename}:\n ${statement.sql} \n ${statement.parameters.map((p) => p.value).join(", ")}`,
         error,

--- a/sqg/src/db/types.ts
+++ b/sqg/src/db/types.ts
@@ -28,6 +28,42 @@ export interface DatabaseEngine {
   close(): Promise<void> | void;
 }
 
+/**
+ * Whether an error is an integrity constraint violation (foreign key, unique,
+ * check, not-null) rather than a problem with the statement itself.
+ */
+export function isConstraintViolation(error: unknown): boolean {
+  const message = (error as Error)?.message ?? "";
+  const code = String((error as { code?: unknown })?.code ?? "");
+  return (
+    code.startsWith("SQLITE_CONSTRAINT") || // better-sqlite3
+    /^23/.test(code) || // postgres: SQLSTATE class 23 (integrity constraint violation)
+    /^Constraint Error/i.test(message) || // duckdb
+    /violates .* constraint|constraint failed/i.test(message)
+  );
+}
+
+/**
+ * Type introspection executes every EXEC statement against whatever data the
+ * MIGRATE and TESTDATA blocks left behind, so a statement can fail purely
+ * because a constraint has nothing to reference — a NOT NULL foreign key can
+ * never be satisfied when no fixture created the parent row.
+ *
+ * Running an EXEC contributes nothing to the generated code (the prepared
+ * statement already supplied the parameter types), so such a failure is
+ * reported as a warning instead of aborting generation. Statements whose
+ * result shape SQG needs (QUERY, including INSERT ... RETURNING) still fail.
+ */
+export function warnConstraintViolation(query: SQLQuery, error: unknown): void {
+  consola.warn(
+    `Skipped executing '${query.id}' in ${query.filename} during type introspection: ` +
+      `${(error as Error).message}\n` +
+      "  Introspection runs each statement against the TESTDATA fixtures only, so constraints " +
+      "such as foreign keys may not be satisfiable. Code generation is unaffected — add a " +
+      "TESTDATA block with the referenced rows to silence this warning.",
+  );
+}
+
 export async function initializeDatabase(
   queries: SQLQuery[],
   execQueries: (query: SQLQuery) => Promise<void>,

--- a/sqg/src/sql-query.ts
+++ b/sqg/src/sql-query.ts
@@ -73,6 +73,25 @@ export type SqlQueryStatement = {
   parameters: ParameterEntry[];
 };
 
+/**
+ * Append a placeholder (`?`, `$1`, `$name`, or an inlined source) to the parts
+ * rendered so far, keeping it separated from the preceding SQL text.
+ *
+ * Without the separator, `LIMIT ${n}` would render as `LIMIT$1` — which
+ * Postgres lexes as the identifier `limit$1` and rejects. The whitespace is
+ * added to the parts themselves so every rendering path (the joined `sql`
+ * string and `sqlParts`, used by the template-literal renderers) agrees.
+ */
+function pushPlaceholder(parts: SqlQueryPart[], placeholder: SqlQueryPart): void {
+  const lastIndex = parts.length - 1;
+  const last = parts[lastIndex];
+  // Only word characters glue onto a placeholder; `(`, `=`, `,` etc. are fine.
+  if (typeof last === "string" && /[A-Za-z0-9_$]$/.test(last)) {
+    parts[lastIndex] = `${last} `;
+  }
+  parts.push(placeholder);
+}
+
 export class SQLQuery {
   columns: ColumnInfo[];
 
@@ -381,30 +400,20 @@ export function parseSQLQueries(filePath: string, extraVariables: ExtraVariable[
         }
 
         toSqlWithAnonymousPlaceholders() {
-          let sql = "";
           const sqlParts: SqlQueryPart[] = [];
           for (const part of this.sqlParts) {
             if (typeof part === "string") {
-              sql += part;
               sqlParts.push(part);
+            } else if (part.name.startsWith("sources_")) {
+              // Sources variables are inlined, not parameterized
+              pushPlaceholder(sqlParts, part);
             } else {
-              if (sql.length > 0) {
-                const last = sql[sql.length - 1];
-                if (last !== " " && last !== "=" && last !== ">" && last !== "<") {
-                  sql += " ";
-                }
-              }
-              sql += "?";
-              if (part.name.startsWith("sources_")) {
-                sqlParts.push(part);
-              } else {
-                sqlParts.push("?");
-              }
+              pushPlaceholder(sqlParts, "?");
             }
           }
           return {
             parameters: this.parameters(),
-            sql: sql,
+            sql: sqlParts.map((part) => (typeof part === "string" ? part : "?")).join(""),
             sqlParts: sqlParts,
           };
         }
@@ -423,7 +432,7 @@ export function parseSQLQueries(filePath: string, extraVariables: ExtraVariable[
 
               // Sources variables are inlined, not parameterized
               if (varName.startsWith("sources_")) {
-                sqlParts.push(part);
+                pushPlaceholder(sqlParts, part);
               } else {
                 let pos = parameters.findIndex((p) => p.name === varName);
                 if (pos < 0) {
@@ -432,7 +441,7 @@ export function parseSQLQueries(filePath: string, extraVariables: ExtraVariable[
                 } else {
                   pos = pos + 1;
                 }
-                sqlParts.push(`$${pos}`);
+                pushPlaceholder(sqlParts, `$${pos}`);
               }
             }
           }
@@ -455,9 +464,9 @@ export function parseSQLQueries(filePath: string, extraVariables: ExtraVariable[
               sqlParts.push(part);
             } else if (part.name.startsWith("sources_")) {
               // Sources variables are inlined
-              sqlParts.push(part);
+              pushPlaceholder(sqlParts, part);
             } else {
-              sqlParts.push(`$${part.name}`);
+              pushPlaceholder(sqlParts, `$${part.name}`);
             }
           }
 
@@ -501,10 +510,15 @@ export function parseSQLQueries(filePath: string, extraVariables: ExtraVariable[
             const varName = varRef.replace("${", "").replace("}", "");
             const value = getVariable(varName);
 
-            if (to > from) {
-              sql.appendSql(content.slice(from, to));
+            // Slice up to the start of the variable, not to the end of the last
+            // token: the whitespace in front of `${...}` is part of the SQL and
+            // must survive, or `LIMIT ${n}` renders as `LIMIT$1` — which
+            // Postgres lexes as an identifier instead of a placeholder.
+            if (from >= 0 && child.from > from) {
+              sql.appendSql(content.slice(from, child.from));
             }
             from = child.to;
+            to = child.to;
             sql.appendVariable(varName, value);
           } else {
             if (from < 0) {

--- a/sqg/tests/__generated__/test-duckdb.ts
+++ b/sqg/tests/__generated__/test-duckdb.ts
@@ -186,7 +186,7 @@ CREATE TABLE tasks (
   }
 
   async insert(name: string, email: string): Promise<DuckDBMaterializedResult> {
-    const sql = "insert into users (name, email) values ( ?, ?);";
+    const sql = "insert into users (name, email) values (?, ?);";
     return await this.conn.run(sql, [name, email]);
   }
 
@@ -221,7 +221,7 @@ CREATE TABLE tasks (
   ): Promise<
     { id: number | null; name: string | null; email: string | null } | undefined
   > {
-    const sql = "select * from users where id =? limit 1;";
+    const sql = "select * from users where id = ? limit 1;";
     const reader = await this.conn.runAndReadAll(sql, [id]);
     return reader.getRowObjects()[0] as
       | { id: number | null; name: string | null; email: string | null }
@@ -233,7 +233,7 @@ CREATE TABLE tasks (
   ): Promise<
     { id: number | null; name: string | null; email: string | null } | undefined
   > {
-    const sql = "select * from users where email =?;";
+    const sql = "select * from users where email = ?;";
     const reader = await this.conn.runAndReadAll(sql, [email]);
     return reader.getRowObjects()[0] as
       | { id: number | null; name: string | null; email: string | null }
@@ -241,7 +241,7 @@ CREATE TABLE tasks (
   }
 
   async getIdByEmail(email: string): Promise<number | null | undefined> {
-    const sql = "select id from users where email =?;";
+    const sql = "select id from users where email = ?;";
     const reader = await this.conn.runAndReadAll(sql, [email]);
     return reader.getRows()[0]?.[0] as number | null | undefined;
   }
@@ -250,12 +250,12 @@ CREATE TABLE tasks (
     id: number,
     email: string,
   ): Promise<DuckDBMaterializedResult> {
-    const sql = "update users set email =? where id =?;";
+    const sql = "update users set email = ? where id = ?;";
     return await this.conn.run(sql, [email, id]);
   }
 
   async delete(id: number): Promise<DuckDBMaterializedResult> {
-    const sql = "delete from users where id =?;";
+    const sql = "delete from users where id = ?;";
     return await this.conn.run(sql, [id]);
   }
 
@@ -270,7 +270,7 @@ CREATE TABLE tasks (
       timestamp: number | null;
     }[]
   > {
-    const sql = "select * from actions where user_id =?;";
+    const sql = "select * from actions where user_id = ?;";
     const reader = await this.conn.runAndReadAll(sql, [user_id]);
     return reader.getRowObjects() as {
       id: number | null;
@@ -295,7 +295,7 @@ CREATE TABLE tasks (
   > {
     const sql = `select * from actions 
  
-  where user_id =? and action =?;`;
+  where user_id = ? and action = ?;`;
     const reader = await this.conn.runAndReadAll(sql, [user_id, action]);
     return reader.getRowObjects() as {
       id: number | null;
@@ -1387,7 +1387,7 @@ CREATE TABLE tasks (
     name: string,
     tags: { items: (string | null)[] },
   ): Promise<DuckDBMaterializedResult> {
-    const sql = "INSERT INTO events (id, name, tags) VALUES ( ?, ?, ?);";
+    const sql = "INSERT INTO events (id, name, tags) VALUES (?, ?, ?);";
     const stmt = await this.conn.prepare(sql);
     stmt.bindValue(1, id);
     stmt.bindValue(2, name);
@@ -1448,7 +1448,7 @@ CREATE TABLE tasks (
     title: string,
     priority: string,
   ): Promise<DuckDBMaterializedResult> {
-    const sql = "INSERT INTO tasks (id, title, priority) VALUES ( ?, ?, ?);";
+    const sql = "INSERT INTO tasks (id, title, priority) VALUES (?, ?, ?);";
     return await this.conn.run(sql, [id, title, priority]);
   }
 
@@ -1461,7 +1461,7 @@ CREATE TABLE tasks (
       priority: "low" | "medium" | "high" | "critical" | null;
     }[]
   > {
-    const sql = "SELECT id, title, priority FROM tasks WHERE priority =?;";
+    const sql = "SELECT id, title, priority FROM tasks WHERE priority = ?;";
     const reader = await this.conn.runAndReadAll(sql, [priority]);
     return reader.getRowObjects() as {
       id: number | null;

--- a/sqg/tests/__snapshots__/TestBaselineAttach.java.snapshot
+++ b/sqg/tests/__snapshots__/TestBaselineAttach.java.snapshot
@@ -238,7 +238,7 @@ public class TestBaselineAttach {
     public GetOrderResult getOrder(Long id) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "select id, customer, total, created_at from prod.public.orders where id =?;"
+                "select id, customer, total, created_at from prod.public.orders where id = ?;"
             )
         ) {
             if (id != null) stmt.setLong(1, id);

--- a/sqg/tests/__snapshots__/TestDuckDbArrow.java.snapshot
+++ b/sqg/tests/__snapshots__/TestDuckDbArrow.java.snapshot
@@ -47,7 +47,7 @@ public class TestDuckDbArrow {
         throws SQLException, IOException {
         var stmt = connection.prepareStatement(
             """
-            insert into users (name, email) values ( ?, ?);"""
+            insert into users (name, email) values (?, ?);"""
         );
         stmt.setObject(1, name);
         stmt.setObject(2, email);
@@ -156,7 +156,7 @@ public class TestDuckDbArrow {
         throws SQLException, IOException {
         var stmt = connection.prepareStatement(
             """
-            update users set email =? where id =?;"""
+            update users set email = ? where id = ?;"""
         );
         stmt.setObject(1, email);
         stmt.setObject(2, id);
@@ -166,7 +166,7 @@ public class TestDuckDbArrow {
     public int delete(Integer id) throws SQLException, IOException {
         var stmt = connection.prepareStatement(
             """
-            delete from users where id =?;"""
+            delete from users where id = ?;"""
         );
         stmt.setObject(1, id);
         return stmt.executeUpdate();
@@ -201,7 +201,7 @@ public class TestDuckDbArrow {
         throws SQLException, IOException {
         var stmt = connection.prepareStatement(
             """
-            select * from actions where user_id =?;"""
+            select * from actions where user_id = ?;"""
         );
         stmt.setObject(1, user_id);
         var rs = (DuckDBResultSet) stmt.executeQuery();
@@ -254,7 +254,7 @@ public class TestDuckDbArrow {
             """
             select * from actions
 
-              where user_id =? and action =?;"""
+              where user_id = ? and action = ?;"""
         );
         stmt.setObject(1, user_id);
         stmt.setObject(2, action);

--- a/sqg/tests/__snapshots__/TestDuckdb.java.snapshot
+++ b/sqg/tests/__snapshots__/TestDuckdb.java.snapshot
@@ -302,7 +302,7 @@ public class TestDuckdb {
     public int insert(String name, String email) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "insert into users (name, email) values (?,?);"
+                "insert into users (name, email) values (?, ?);"
             )
         ) {
             stmt.setString(1, name);
@@ -465,7 +465,7 @@ public class TestDuckdb {
     public ByIdResult byId(Integer id) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "select * from users where id =? limit 1;"
+                "select * from users where id = ? limit 1;"
             )
         ) {
             if (id != null) stmt.setInt(1, id);
@@ -488,7 +488,7 @@ public class TestDuckdb {
     public ByEmailResult byEmail(String email) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "select * from users where email =?;"
+                "select * from users where email = ?;"
             )
         ) {
             stmt.setString(1, email);
@@ -508,7 +508,7 @@ public class TestDuckdb {
     public Integer getIdByEmail(String email) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "select id from users where email =?;"
+                "select id from users where email = ?;"
             )
         ) {
             stmt.setString(1, email);
@@ -522,7 +522,7 @@ public class TestDuckdb {
     public int updateEmail(Integer id, String email) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "update users set email =? where id =?;"
+                "update users set email = ? where id = ?;"
             )
         ) {
             stmt.setString(1, email);
@@ -536,7 +536,7 @@ public class TestDuckdb {
     public int delete(Integer id) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "delete from users where id =?;"
+                "delete from users where id = ?;"
             )
         ) {
             if (id != null) stmt.setInt(1, id);
@@ -558,7 +558,7 @@ public class TestDuckdb {
         throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "select * from actions where user_id =?;"
+                "select * from actions where user_id = ?;"
             )
         ) {
             if (user_id != null) stmt.setInt(1, user_id);
@@ -592,7 +592,7 @@ public class TestDuckdb {
         StreamOptions options
     ) throws SQLException {
         var stmt = connection.prepareStatement(
-            "select * from actions where user_id =?;"
+            "select * from actions where user_id = ?;"
         );
         if (options.fetchSize() > 0) stmt.setFetchSize(options.fetchSize());
         if (user_id != null) stmt.setInt(1, user_id);
@@ -659,7 +659,7 @@ public class TestDuckdb {
                 """
                 select * from actions
 
-                  where user_id =? and action =?;"""
+                  where user_id = ? and action = ?;"""
             )
         ) {
             if (user_id != null) stmt.setInt(1, user_id);
@@ -706,7 +706,7 @@ public class TestDuckdb {
             """
             select * from actions
 
-              where user_id =? and action =?;"""
+              where user_id = ? and action = ?;"""
         );
         if (options.fetchSize() > 0) stmt.setFetchSize(options.fetchSize());
         if (user_id != null) stmt.setInt(1, user_id);
@@ -837,7 +837,7 @@ public class TestDuckdb {
     public List<TestResult> test(Integer a) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "select 1 as n where? ::int is null;"
+                "select 1 as n where ? ::int is null;"
             )
         ) {
             if (a != null) stmt.setInt(1, a);
@@ -860,7 +860,7 @@ public class TestDuckdb {
     public Stream<TestResult> testStream(Integer a, StreamOptions options)
         throws SQLException {
         var stmt = connection.prepareStatement(
-            "select 1 as n where? ::int is null;"
+            "select 1 as n where ? ::int is null;"
         );
         if (options.fetchSize() > 0) stmt.setFetchSize(options.fetchSize());
         if (a != null) stmt.setInt(1, a);
@@ -2317,7 +2317,7 @@ public class TestDuckdb {
         throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "INSERT INTO events (id, name, tags) VALUES (?,?,?);"
+                "INSERT INTO events (id, name, tags) VALUES (?, ?, ?);"
             )
         ) {
             if (id != null) stmt.setInt(1, id);
@@ -2569,7 +2569,7 @@ public class TestDuckdb {
         throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "INSERT INTO tasks (id, title, priority) VALUES (?,?,?);"
+                "INSERT INTO tasks (id, title, priority) VALUES (?, ?, ?);"
             )
         ) {
             if (id != null) stmt.setInt(1, id);
@@ -2592,7 +2592,7 @@ public class TestDuckdb {
     ) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "SELECT id, title, priority FROM tasks WHERE priority =?;"
+                "SELECT id, title, priority FROM tasks WHERE priority = ?;"
             )
         ) {
             stmt.setObject(1, priority.getValue());
@@ -2624,7 +2624,7 @@ public class TestDuckdb {
         StreamOptions options
     ) throws SQLException {
         var stmt = connection.prepareStatement(
-            "SELECT id, title, priority FROM tasks WHERE priority =?;"
+            "SELECT id, title, priority FROM tasks WHERE priority = ?;"
         );
         if (options.fetchSize() > 0) stmt.setFetchSize(options.fetchSize());
         stmt.setObject(1, priority.getValue());

--- a/sqg/tests/__snapshots__/TestObserver.java.snapshot
+++ b/sqg/tests/__snapshots__/TestObserver.java.snapshot
@@ -353,7 +353,7 @@ public class TestObserver {
         try {
             try (
                 var stmt = connection.prepareStatement(
-                    "select id, name, email from users where id =?;"
+                    "select id, name, email from users where id = ?;"
                 )
             ) {
                 if (id != null) stmt.setInt(1, id);
@@ -387,7 +387,7 @@ public class TestObserver {
         try {
             try (
                 var stmt = connection.prepareStatement(
-                    "select name from users where id =?;"
+                    "select name from users where id = ?;"
                 )
             ) {
                 if (id != null) stmt.setInt(1, id);
@@ -416,7 +416,7 @@ public class TestObserver {
         try {
             try (
                 var stmt = connection.prepareStatement(
-                    "insert into users (id, name, email) values (?,?,?);"
+                    "insert into users (id, name, email) values (?, ?, ?);"
                 )
             ) {
                 if (id != null) stmt.setInt(1, id);
@@ -445,7 +445,7 @@ public class TestObserver {
         try {
             try (
                 var stmt = connection.prepareStatement(
-                    "insert into users (id, name, email) values (?,?,?);"
+                    "insert into users (id, name, email) values (?, ?, ?);"
                 )
             ) {
                 if (id != null) stmt.setInt(1, id);
@@ -480,7 +480,7 @@ public class TestObserver {
         try {
             try (
                 var stmt = connection.prepareStatement(
-                    "insert into users (id, name, email) values (?,?,?);"
+                    "insert into users (id, name, email) values (?, ?, ?);"
                 )
             ) {
                 long __n = 0;

--- a/sqg/tests/__snapshots__/TestPg.java.snapshot
+++ b/sqg/tests/__snapshots__/TestPg.java.snapshot
@@ -556,7 +556,7 @@ public class TestPg {
     public Users6Result users6(String name) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "SELECT * FROM users WHERE name =?"
+                "SELECT * FROM users WHERE name = ?"
             )
         ) {
             stmt.setString(1, name);
@@ -578,7 +578,7 @@ public class TestPg {
     public List<Users7Result> users7(String name) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "SELECT * FROM users WHERE name =?"
+                "SELECT * FROM users WHERE name = ?"
             )
         ) {
             stmt.setString(1, name);
@@ -608,7 +608,7 @@ public class TestPg {
         boolean wasAutoCommit = connection.getAutoCommit();
         if (wasAutoCommit) connection.setAutoCommit(false);
         var stmt = connection.prepareStatement(
-            "SELECT * FROM users WHERE name =?"
+            "SELECT * FROM users WHERE name = ?"
         );
         if (options.fetchSize() > 0) stmt.setFetchSize(options.fetchSize());
         stmt.setString(1, name);
@@ -668,7 +668,7 @@ public class TestPg {
         throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "SELECT id, title, status, tags, priority_scores FROM tasks WHERE status =?::task_status;"
+                "SELECT id, title, status, tags, priority_scores FROM tasks WHERE status = ?::task_status;"
             )
         ) {
             stmt.setObject(1, status.getValue());
@@ -710,7 +710,7 @@ public class TestPg {
         boolean wasAutoCommit = connection.getAutoCommit();
         if (wasAutoCommit) connection.setAutoCommit(false);
         var stmt = connection.prepareStatement(
-            "SELECT id, title, status, tags, priority_scores FROM tasks WHERE status =?::task_status;"
+            "SELECT id, title, status, tags, priority_scores FROM tasks WHERE status = ?::task_status;"
         );
         if (options.fetchSize() > 0) stmt.setFetchSize(options.fetchSize());
         stmt.setObject(1, status.getValue());
@@ -892,7 +892,7 @@ public class TestPg {
     ) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "INSERT INTO tasks (title, status, tags, priority_scores) VALUES (?,?::task_status,?,?);"
+                "INSERT INTO tasks (title, status, tags, priority_scores) VALUES (?, ?::task_status, ?, ?);"
             )
         ) {
             stmt.setString(1, title);
@@ -918,7 +918,7 @@ public class TestPg {
         throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "INSERT INTO tasks (title, status, tags, priority_scores) VALUES (?,?::task_status,?,?);"
+                "INSERT INTO tasks (title, status, tags, priority_scores) VALUES (?, ?::task_status, ?, ?);"
             )
         ) {
             for (var row : params) {
@@ -951,7 +951,7 @@ public class TestPg {
     ) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "INSERT INTO bigint_test (id, small_id, regular_id, amount, name) VALUES (?,?,?,?,?);"
+                "INSERT INTO bigint_test (id, small_id, regular_id, amount, name) VALUES (?, ?, ?, ?, ?);"
             )
         ) {
             if (id != null) stmt.setLong(1, id);
@@ -981,7 +981,7 @@ public class TestPg {
     ) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "INSERT INTO bigint_test (id, small_id, regular_id, amount, name) VALUES (?,?,?,?,?);"
+                "INSERT INTO bigint_test (id, small_id, regular_id, amount, name) VALUES (?, ?, ?, ?, ?);"
             )
         ) {
             for (var row : params) {
@@ -1013,7 +1013,7 @@ public class TestPg {
     public GetBigintRecordResult getBigintRecord(Long id) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "SELECT id, serial_id, small_id, regular_id, amount, name FROM bigint_test WHERE id =?;"
+                "SELECT id, serial_id, small_id, regular_id, amount, name FROM bigint_test WHERE id = ?;"
             )
         ) {
             if (id != null) stmt.setLong(1, id);
@@ -1037,7 +1037,7 @@ public class TestPg {
     public Long getBigintAmount(Long id) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "SELECT amount FROM bigint_test WHERE id =?;"
+                "SELECT amount FROM bigint_test WHERE id = ?;"
             )
         ) {
             if (id != null) stmt.setLong(1, id);
@@ -1172,7 +1172,7 @@ public class TestPg {
     public int insertUuid(UUID id, String label) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "INSERT INTO uuid_test (id, label) VALUES (?::uuid,?);"
+                "INSERT INTO uuid_test (id, label) VALUES (?::uuid, ?);"
             )
         ) {
             stmt.setObject(1, id);
@@ -1188,7 +1188,7 @@ public class TestPg {
         throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "INSERT INTO uuid_test (id, label) VALUES (?::uuid,?);"
+                "INSERT INTO uuid_test (id, label) VALUES (?::uuid, ?);"
             )
         ) {
             for (var row : params) {
@@ -1206,7 +1206,7 @@ public class TestPg {
     public GetUuidByIdResult getUuidById(UUID id) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "SELECT id, label FROM uuid_test WHERE id =?::uuid;"
+                "SELECT id, label FROM uuid_test WHERE id = ?::uuid;"
             )
         ) {
             stmt.setObject(1, id);
@@ -1226,7 +1226,7 @@ public class TestPg {
         throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "INSERT INTO users (id, name, email) VALUES (?,?,?);"
+                "INSERT INTO users (id, name, email) VALUES (?, ?, ?);"
             )
         ) {
             stmt.setString(1, id);
@@ -1243,7 +1243,7 @@ public class TestPg {
         throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "INSERT INTO users (id, name, email) VALUES (?,?,?);"
+                "INSERT INTO users (id, name, email) VALUES (?, ?, ?);"
             )
         ) {
             for (var row : params) {
@@ -1260,7 +1260,7 @@ public class TestPg {
     public int updateUserEmail(String id, String email) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "UPDATE users SET email =? WHERE id =?;"
+                "UPDATE users SET email = ? WHERE id = ?;"
             )
         ) {
             stmt.setString(1, email);
@@ -1276,7 +1276,7 @@ public class TestPg {
         throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "UPDATE users SET email =? WHERE id =?;"
+                "UPDATE users SET email = ? WHERE id = ?;"
             )
         ) {
             for (var row : params) {
@@ -1292,7 +1292,7 @@ public class TestPg {
     public int deleteUser(String id) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "DELETE FROM users WHERE id =?;"
+                "DELETE FROM users WHERE id = ?;"
             )
         ) {
             stmt.setString(1, id);
@@ -1304,7 +1304,7 @@ public class TestPg {
     public int[] deleteUserBatch(Iterable<String> params) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "DELETE FROM users WHERE id =?;"
+                "DELETE FROM users WHERE id = ?;"
             )
         ) {
             for (var value : params) {
@@ -1428,7 +1428,7 @@ public class TestPg {
         throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "SELECT * FROM all_types_test WHERE id =?;"
+                "SELECT * FROM all_types_test WHERE id = ?;"
             )
         ) {
             if (id != null) stmt.setInt(1, id);

--- a/sqg/tests/__snapshots__/TestPostgresSource.java.snapshot
+++ b/sqg/tests/__snapshots__/TestPostgresSource.java.snapshot
@@ -249,7 +249,7 @@ public class TestPostgresSource {
     public GetOrderResult getOrder(Long id) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "select id, customer, total, created_at from prod.public.orders where id =?;"
+                "select id, customer, total, created_at from prod.public.orders where id = ?;"
             )
         ) {
             if (id != null) stmt.setLong(1, id);

--- a/sqg/tests/__snapshots__/TestSources.java.snapshot
+++ b/sqg/tests/__snapshots__/TestSources.java.snapshot
@@ -294,7 +294,7 @@ public class TestSources {
     public int attach(String sources_users) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "attach '" +
+                "attach  '" +
                     sources_users +
                     """
                     ' as "users" (TYPE SQLITE);"""

--- a/sqg/tests/__snapshots__/TestSqlite.java.snapshot
+++ b/sqg/tests/__snapshots__/TestSqlite.java.snapshot
@@ -572,7 +572,7 @@ public class TestSqlite {
     public Users6Result users6(String name) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "SELECT * FROM users WHERE name =?"
+                "SELECT * FROM users WHERE name = ?"
             )
         ) {
             stmt.setString(1, name);
@@ -594,7 +594,7 @@ public class TestSqlite {
     public List<Users7Result> users7(String name) throws SQLException {
         try (
             var stmt = connection.prepareStatement(
-                "SELECT * FROM users WHERE name =?"
+                "SELECT * FROM users WHERE name = ?"
             )
         ) {
             stmt.setString(1, name);
@@ -622,7 +622,7 @@ public class TestSqlite {
     public Stream<Users7Result> users7Stream(String name, StreamOptions options)
         throws SQLException {
         var stmt = connection.prepareStatement(
-            "SELECT * FROM users WHERE name =?"
+            "SELECT * FROM users WHERE name = ?"
         );
         if (options.fetchSize() > 0) stmt.setFetchSize(options.fetchSize());
         stmt.setString(1, name);

--- a/sqg/tests/__snapshots__/libsql-test-sqlite.ts.snapshot
+++ b/sqg/tests/__snapshots__/libsql-test-sqlite.ts.snapshot
@@ -212,7 +212,7 @@ export class TestSqlite {
     name: string,
   ): Promise<{ id: string; name: string; email: string } | undefined> {
     const result = await this.client.execute({
-      sql: "SELECT * FROM users WHERE name =?",
+      sql: "SELECT * FROM users WHERE name = ?",
       args: [name] as InArgs,
     });
     return (result.rows as unknown[])[0] as
@@ -223,7 +223,7 @@ export class TestSqlite {
     name: string,
   ): Promise<{ id: string; name: string; email: string | null }[]> {
     const result = await this.client.execute({
-      sql: "SELECT * FROM users WHERE name =?",
+      sql: "SELECT * FROM users WHERE name = ?",
       args: [name] as InArgs,
     });
     return result.rows as unknown[] as {

--- a/sqg/tests/__snapshots__/node-test-sqlite.ts.snapshot
+++ b/sqg/tests/__snapshots__/node-test-sqlite.ts.snapshot
@@ -188,13 +188,13 @@ export class TestSqlite {
   users6(
     name: string,
   ): { id: string; name: string; email: string } | undefined {
-    const stmt = this.prepare("users6", "SELECT * FROM users WHERE name =?");
+    const stmt = this.prepare("users6", "SELECT * FROM users WHERE name = ?");
     return stmt.get(name) as
       | { id: string; name: string; email: string }
       | undefined;
   }
   users7(name: string): { id: string; name: string; email: string | null }[] {
-    const stmt = this.prepare("users7", "SELECT * FROM users WHERE name =?");
+    const stmt = this.prepare("users7", "SELECT * FROM users WHERE name = ?");
     return stmt.all(name) as {
       id: string;
       name: string;

--- a/sqg/tests/__snapshots__/python-test_duckdb.py.snapshot
+++ b/sqg/tests/__snapshots__/python-test_duckdb.py.snapshot
@@ -396,7 +396,7 @@ CREATE TABLE tasks (
 
     def insert(self, name: str, email: str) -> None:
         self._conn.execute(
-            "insert into users (name, email) values ($1,$2);", [name, email]
+            "insert into users (name, email) values ($1, $2);", [name, email]
         )
 
     def all(self) -> list[AllRow]:
@@ -425,7 +425,7 @@ select 'abc' as a,1 as x,* from users;""", []
 
     def by_id(self, id: int) -> ByIdRow | None:
         row = self._conn.execute(
-            "select * from users where id =$1 limit 1;", [id]
+            "select * from users where id = $1 limit 1;", [id]
         ).fetchone()
         if row is None:
             return None
@@ -433,12 +433,12 @@ select 'abc' as a,1 as x,* from users;""", []
 
     def by_id_raw(self, id: int) -> tuple[Any, ...] | None:
         return self._conn.execute(
-            "select * from users where id =$1 limit 1;", [id]
+            "select * from users where id = $1 limit 1;", [id]
         ).fetchone()
 
     def by_email(self, email: str) -> ByEmailRow | None:
         row = self._conn.execute(
-            "select * from users where email =$1;", [email]
+            "select * from users where email = $1;", [email]
         ).fetchone()
         if row is None:
             return None
@@ -446,12 +446,12 @@ select 'abc' as a,1 as x,* from users;""", []
 
     def by_email_raw(self, email: str) -> tuple[Any, ...] | None:
         return self._conn.execute(
-            "select * from users where email =$1;", [email]
+            "select * from users where email = $1;", [email]
         ).fetchone()
 
     def get_id_by_email(self, email: str) -> int | None:
         row = self._conn.execute(
-            "select id from users where email =$1;", [email]
+            "select id from users where email = $1;", [email]
         ).fetchone()
         if row is None:
             return None
@@ -459,28 +459,28 @@ select 'abc' as a,1 as x,* from users;""", []
 
     def get_id_by_email_raw(self, email: str) -> tuple[Any, ...] | None:
         return self._conn.execute(
-            "select id from users where email =$1;", [email]
+            "select id from users where email = $1;", [email]
         ).fetchone()
 
     def update_email(self, id: int, email: str) -> None:
         self._conn.execute(
-            "update users set email =$1 where id =$2;", [email, id]
+            "update users set email = $1 where id = $2;", [email, id]
         )
 
     def delete(self, id: int) -> None:
         self._conn.execute(
-            "delete from users where id =$1;", [id]
+            "delete from users where id = $1;", [id]
         )
 
     def actions_by_user_id(self, user_id: int) -> list[ActionsByUserIdRow]:
         rows = self._conn.execute(
-            "select * from actions where user_id =$1;", [user_id]
+            "select * from actions where user_id = $1;", [user_id]
         ).fetchall()
         return [ActionsByUserIdRow(id=row[0], action=row[1], value=row[2], user_id=row[3], timestamp=row[4]) for row in rows]
 
     def actions_by_user_id_raw(self, user_id: int) -> list[tuple[Any, ...]]:
         return self._conn.execute(
-            "select * from actions where user_id =$1;", [user_id]
+            "select * from actions where user_id = $1;", [user_id]
         ).fetchall()
 
     def actions_by_user_id_and_action(self, user_id: int, action: str) -> list[ActionsByUserIdAndActionRow]:
@@ -488,7 +488,7 @@ select 'abc' as a,1 as x,* from users;""", []
             """\
 select * from actions 
  
-  where user_id =$1 and action =$2;""", [user_id, action]
+  where user_id = $1 and action = $2;""", [user_id, action]
         ).fetchall()
         return [ActionsByUserIdAndActionRow(id=row[0], action=row[1], value=row[2], user_id=row[3], timestamp=row[4]) for row in rows]
 
@@ -497,7 +497,7 @@ select * from actions
             """\
 select * from actions 
  
-  where user_id =$1 and action =$2;""", [user_id, action]
+  where user_id = $1 and action = $2;""", [user_id, action]
         ).fetchall()
 
     def top_users(self) -> list[TopUsersRow]:
@@ -513,13 +513,13 @@ select * from actions
 
     def test(self, a: int) -> list[TestRow]:
         rows = self._conn.execute(
-            "select 1 as n where$1 ::int is null;", [a]
+            "select 1 as n where $1 ::int is null;", [a]
         ).fetchall()
         return [TestRow(n=row[0]) for row in rows]
 
     def test_raw(self, a: int) -> list[tuple[Any, ...]]:
         return self._conn.execute(
-            "select 1 as n where$1 ::int is null;", [a]
+            "select 1 as n where $1 ::int is null;", [a]
         ).fetchall()
 
     def test_2(self) -> list[Test2Row]:
@@ -775,7 +775,7 @@ select a:[1,2,3] ,b:2, c: {'x' : [{'a' : 1}], 'y' : {'z' : 3}}""", []
 
     def insert_event(self, id: int, name: str, tags: list[str | None]) -> None:
         self._conn.execute(
-            "INSERT INTO events (id, name, tags) VALUES ($1,$2,$3);", [id, name, tags]
+            "INSERT INTO events (id, name, tags) VALUES ($1, $2, $3);", [id, name, tags]
         )
 
     def all_events(self) -> list[AllEventsRow]:
@@ -813,18 +813,18 @@ select a:[1,2,3] ,b:2, c: {'x' : [{'a' : 1}], 'y' : {'z' : 3}}""", []
 
     def insert_task(self, id: int, title: str, priority: str) -> None:
         self._conn.execute(
-            "INSERT INTO tasks (id, title, priority) VALUES ($1,$2,$3);", [id, title, priority]
+            "INSERT INTO tasks (id, title, priority) VALUES ($1, $2, $3);", [id, title, priority]
         )
 
     def get_tasks_by_priority(self, priority: str) -> list[GetTasksByPriorityRow]:
         rows = self._conn.execute(
-            "SELECT id, title, priority FROM tasks WHERE priority =$1;", [priority]
+            "SELECT id, title, priority FROM tasks WHERE priority = $1;", [priority]
         ).fetchall()
         return [GetTasksByPriorityRow(id=row[0], title=row[1], priority=row[2]) for row in rows]
 
     def get_tasks_by_priority_raw(self, priority: str) -> list[tuple[Any, ...]]:
         return self._conn.execute(
-            "SELECT id, title, priority FROM tasks WHERE priority =$1;", [priority]
+            "SELECT id, title, priority FROM tasks WHERE priority = $1;", [priority]
         ).fetchall()
 
     def get_all_tasks(self) -> list[GetAllTasksRow]:

--- a/sqg/tests/__snapshots__/python-test_sqlite.py.snapshot
+++ b/sqg/tests/__snapshots__/python-test_sqlite.py.snapshot
@@ -280,7 +280,7 @@ select 10 count, email from users where id = '1';""", ()
 
     def users_6(self, name: str) -> Users6Row | None:
         row = self._conn.execute(
-            "SELECT * FROM users WHERE name =?", (name, )
+            "SELECT * FROM users WHERE name = ?", (name, )
         ).fetchone()
         if row is None:
             return None
@@ -288,18 +288,18 @@ select 10 count, email from users where id = '1';""", ()
 
     def users_6_raw(self, name: str) -> tuple[Any, ...] | None:
         return self._conn.execute(
-            "SELECT * FROM users WHERE name =?", (name, )
+            "SELECT * FROM users WHERE name = ?", (name, )
         ).fetchone()
 
     def users_7(self, name: str) -> list[Users7Row]:
         rows = self._conn.execute(
-            "SELECT * FROM users WHERE name =?", (name, )
+            "SELECT * FROM users WHERE name = ?", (name, )
         ).fetchall()
         return [Users7Row(id=row[0], name=row[1], email=row[2]) for row in rows]
 
     def users_7_raw(self, name: str) -> list[tuple[Any, ...]]:
         return self._conn.execute(
-            "SELECT * FROM users WHERE name =?", (name, )
+            "SELECT * FROM users WHERE name = ?", (name, )
         ).fetchall()
 
     def reserved_word_test(self) -> ReservedWordTestRow | None:

--- a/sqg/tests/__snapshots__/safe-integers-test-sqlite.ts.snapshot
+++ b/sqg/tests/__snapshots__/safe-integers-test-sqlite.ts.snapshot
@@ -205,14 +205,14 @@ export class TestSqlite {
     const stmt = this.prepare<
       [string],
       { id: string; name: string; email: string }
-    >("users6", "SELECT * FROM users WHERE name =?");
+    >("users6", "SELECT * FROM users WHERE name = ?");
     return stmt.get(name);
   }
   users7(name: string): { id: string; name: string; email: string | null }[] {
     const stmt = this.prepare<
       [string],
       { id: string; name: string; email: string | null }
-    >("users7", "SELECT * FROM users WHERE name =?");
+    >("users7", "SELECT * FROM users WHERE name = ?");
     return stmt.all(name);
   }
   reservedWordTest(): { class: string; type: string } | undefined {

--- a/sqg/tests/__snapshots__/test-duckdb.ts.snapshot
+++ b/sqg/tests/__snapshots__/test-duckdb.ts.snapshot
@@ -186,7 +186,7 @@ CREATE TABLE tasks (
   }
 
   async insert(name: string, email: string): Promise<DuckDBMaterializedResult> {
-    const sql = "insert into users (name, email) values ( ?, ?);";
+    const sql = "insert into users (name, email) values (?, ?);";
     return await this.conn.run(sql, [name, email]);
   }
 
@@ -221,7 +221,7 @@ CREATE TABLE tasks (
   ): Promise<
     { id: number | null; name: string | null; email: string | null } | undefined
   > {
-    const sql = "select * from users where id =? limit 1;";
+    const sql = "select * from users where id = ? limit 1;";
     const reader = await this.conn.runAndReadAll(sql, [id]);
     return reader.getRowObjects()[0] as
       | { id: number | null; name: string | null; email: string | null }
@@ -233,7 +233,7 @@ CREATE TABLE tasks (
   ): Promise<
     { id: number | null; name: string | null; email: string | null } | undefined
   > {
-    const sql = "select * from users where email =?;";
+    const sql = "select * from users where email = ?;";
     const reader = await this.conn.runAndReadAll(sql, [email]);
     return reader.getRowObjects()[0] as
       | { id: number | null; name: string | null; email: string | null }
@@ -241,7 +241,7 @@ CREATE TABLE tasks (
   }
 
   async getIdByEmail(email: string): Promise<number | null | undefined> {
-    const sql = "select id from users where email =?;";
+    const sql = "select id from users where email = ?;";
     const reader = await this.conn.runAndReadAll(sql, [email]);
     return reader.getRows()[0]?.[0] as number | null | undefined;
   }
@@ -250,12 +250,12 @@ CREATE TABLE tasks (
     id: number,
     email: string,
   ): Promise<DuckDBMaterializedResult> {
-    const sql = "update users set email =? where id =?;";
+    const sql = "update users set email = ? where id = ?;";
     return await this.conn.run(sql, [email, id]);
   }
 
   async delete(id: number): Promise<DuckDBMaterializedResult> {
-    const sql = "delete from users where id =?;";
+    const sql = "delete from users where id = ?;";
     return await this.conn.run(sql, [id]);
   }
 
@@ -270,7 +270,7 @@ CREATE TABLE tasks (
       timestamp: number | null;
     }[]
   > {
-    const sql = "select * from actions where user_id =?;";
+    const sql = "select * from actions where user_id = ?;";
     const reader = await this.conn.runAndReadAll(sql, [user_id]);
     return reader.getRowObjects() as {
       id: number | null;
@@ -295,7 +295,7 @@ CREATE TABLE tasks (
   > {
     const sql = `select * from actions 
  
-  where user_id =? and action =?;`;
+  where user_id = ? and action = ?;`;
     const reader = await this.conn.runAndReadAll(sql, [user_id, action]);
     return reader.getRowObjects() as {
       id: number | null;
@@ -1387,7 +1387,7 @@ CREATE TABLE tasks (
     name: string,
     tags: { items: (string | null)[] },
   ): Promise<DuckDBMaterializedResult> {
-    const sql = "INSERT INTO events (id, name, tags) VALUES ( ?, ?, ?);";
+    const sql = "INSERT INTO events (id, name, tags) VALUES (?, ?, ?);";
     const stmt = await this.conn.prepare(sql);
     stmt.bindValue(1, id);
     stmt.bindValue(2, name);
@@ -1448,7 +1448,7 @@ CREATE TABLE tasks (
     title: string,
     priority: string,
   ): Promise<DuckDBMaterializedResult> {
-    const sql = "INSERT INTO tasks (id, title, priority) VALUES ( ?, ?, ?);";
+    const sql = "INSERT INTO tasks (id, title, priority) VALUES (?, ?, ?);";
     return await this.conn.run(sql, [id, title, priority]);
   }
 
@@ -1461,7 +1461,7 @@ CREATE TABLE tasks (
       priority: "low" | "medium" | "high" | "critical" | null;
     }[]
   > {
-    const sql = "SELECT id, title, priority FROM tasks WHERE priority =?;";
+    const sql = "SELECT id, title, priority FROM tasks WHERE priority = ?;";
     const reader = await this.conn.runAndReadAll(sql, [priority]);
     return reader.getRowObjects() as {
       id: number | null;

--- a/sqg/tests/__snapshots__/test-postgres-source.ts.snapshot
+++ b/sqg/tests/__snapshots__/test-postgres-source.ts.snapshot
@@ -89,7 +89,7 @@ export class TestPostgresSource {
     | undefined
   > {
     const sql =
-      "select id, customer, total, created_at from prod.public.orders where id =?;";
+      "select id, customer, total, created_at from prod.public.orders where id = ?;";
     const reader = await this.conn.runAndReadAll(sql, [id]);
     return reader.getRowObjects()[0] as
       | {

--- a/sqg/tests/__snapshots__/test-sources.ts.snapshot
+++ b/sqg/tests/__snapshots__/test-sources.ts.snapshot
@@ -78,7 +78,7 @@ export class TestSources {
   }
 
   async attach(sources_users: string): Promise<DuckDBMaterializedResult> {
-    const sql = `attach '${sources_users}' as "users" (TYPE SQLITE);`;
+    const sql = `attach  '${sources_users}' as "users" (TYPE SQLITE);`;
     return await this.conn.run(sql, []);
   }
 

--- a/sqg/tests/__snapshots__/test-sqlite.ts.snapshot
+++ b/sqg/tests/__snapshots__/test-sqlite.ts.snapshot
@@ -202,14 +202,14 @@ export class TestSqlite {
     const stmt = this.prepare<
       [string],
       { id: string; name: string; email: string }
-    >("users6", "SELECT * FROM users WHERE name =?");
+    >("users6", "SELECT * FROM users WHERE name = ?");
     return stmt.get(name);
   }
   users7(name: string): { id: string; name: string; email: string | null }[] {
     const stmt = this.prepare<
       [string],
       { id: string; name: string; email: string | null }
-    >("users7", "SELECT * FROM users WHERE name =?");
+    >("users7", "SELECT * FROM users WHERE name = ?");
     return stmt.all(name);
   }
   reservedWordTest(): { class: string; type: string } | undefined {

--- a/sqg/tests/__snapshots__/test_duckdb.py.snapshot
+++ b/sqg/tests/__snapshots__/test_duckdb.py.snapshot
@@ -396,7 +396,7 @@ CREATE TABLE tasks (
 
     def insert(self, name: str, email: str) -> None:
         self._conn.execute(
-            "insert into users (name, email) values ($1,$2);", [name, email]
+            "insert into users (name, email) values ($1, $2);", [name, email]
         )
 
     def all(self) -> list[AllRow]:
@@ -425,7 +425,7 @@ select 'abc' as a,1 as x,* from users;""", []
 
     def by_id(self, id: int) -> ByIdRow | None:
         row = self._conn.execute(
-            "select * from users where id =$1 limit 1;", [id]
+            "select * from users where id = $1 limit 1;", [id]
         ).fetchone()
         if row is None:
             return None
@@ -433,12 +433,12 @@ select 'abc' as a,1 as x,* from users;""", []
 
     def by_id_raw(self, id: int) -> tuple[Any, ...] | None:
         return self._conn.execute(
-            "select * from users where id =$1 limit 1;", [id]
+            "select * from users where id = $1 limit 1;", [id]
         ).fetchone()
 
     def by_email(self, email: str) -> ByEmailRow | None:
         row = self._conn.execute(
-            "select * from users where email =$1;", [email]
+            "select * from users where email = $1;", [email]
         ).fetchone()
         if row is None:
             return None
@@ -446,12 +446,12 @@ select 'abc' as a,1 as x,* from users;""", []
 
     def by_email_raw(self, email: str) -> tuple[Any, ...] | None:
         return self._conn.execute(
-            "select * from users where email =$1;", [email]
+            "select * from users where email = $1;", [email]
         ).fetchone()
 
     def get_id_by_email(self, email: str) -> int | None:
         row = self._conn.execute(
-            "select id from users where email =$1;", [email]
+            "select id from users where email = $1;", [email]
         ).fetchone()
         if row is None:
             return None
@@ -459,28 +459,28 @@ select 'abc' as a,1 as x,* from users;""", []
 
     def get_id_by_email_raw(self, email: str) -> tuple[Any, ...] | None:
         return self._conn.execute(
-            "select id from users where email =$1;", [email]
+            "select id from users where email = $1;", [email]
         ).fetchone()
 
     def update_email(self, id: int, email: str) -> None:
         self._conn.execute(
-            "update users set email =$1 where id =$2;", [email, id]
+            "update users set email = $1 where id = $2;", [email, id]
         )
 
     def delete(self, id: int) -> None:
         self._conn.execute(
-            "delete from users where id =$1;", [id]
+            "delete from users where id = $1;", [id]
         )
 
     def actions_by_user_id(self, user_id: int) -> list[ActionsByUserIdRow]:
         rows = self._conn.execute(
-            "select * from actions where user_id =$1;", [user_id]
+            "select * from actions where user_id = $1;", [user_id]
         ).fetchall()
         return [ActionsByUserIdRow(id=row[0], action=row[1], value=row[2], user_id=row[3], timestamp=row[4]) for row in rows]
 
     def actions_by_user_id_raw(self, user_id: int) -> list[tuple[Any, ...]]:
         return self._conn.execute(
-            "select * from actions where user_id =$1;", [user_id]
+            "select * from actions where user_id = $1;", [user_id]
         ).fetchall()
 
     def actions_by_user_id_and_action(self, user_id: int, action: str) -> list[ActionsByUserIdAndActionRow]:
@@ -488,7 +488,7 @@ select 'abc' as a,1 as x,* from users;""", []
             """\
 select * from actions 
  
-  where user_id =$1 and action =$2;""", [user_id, action]
+  where user_id = $1 and action = $2;""", [user_id, action]
         ).fetchall()
         return [ActionsByUserIdAndActionRow(id=row[0], action=row[1], value=row[2], user_id=row[3], timestamp=row[4]) for row in rows]
 
@@ -497,7 +497,7 @@ select * from actions
             """\
 select * from actions 
  
-  where user_id =$1 and action =$2;""", [user_id, action]
+  where user_id = $1 and action = $2;""", [user_id, action]
         ).fetchall()
 
     def top_users(self) -> list[TopUsersRow]:
@@ -513,13 +513,13 @@ select * from actions
 
     def test(self, a: int) -> list[TestRow]:
         rows = self._conn.execute(
-            "select 1 as n where$1 ::int is null;", [a]
+            "select 1 as n where $1 ::int is null;", [a]
         ).fetchall()
         return [TestRow(n=row[0]) for row in rows]
 
     def test_raw(self, a: int) -> list[tuple[Any, ...]]:
         return self._conn.execute(
-            "select 1 as n where$1 ::int is null;", [a]
+            "select 1 as n where $1 ::int is null;", [a]
         ).fetchall()
 
     def test_2(self) -> list[Test2Row]:
@@ -775,7 +775,7 @@ select a:[1,2,3] ,b:2, c: {'x' : [{'a' : 1}], 'y' : {'z' : 3}}""", []
 
     def insert_event(self, id: int, name: str, tags: list[str | None]) -> None:
         self._conn.execute(
-            "INSERT INTO events (id, name, tags) VALUES ($1,$2,$3);", [id, name, tags]
+            "INSERT INTO events (id, name, tags) VALUES ($1, $2, $3);", [id, name, tags]
         )
 
     def all_events(self) -> list[AllEventsRow]:
@@ -813,18 +813,18 @@ select a:[1,2,3] ,b:2, c: {'x' : [{'a' : 1}], 'y' : {'z' : 3}}""", []
 
     def insert_task(self, id: int, title: str, priority: str) -> None:
         self._conn.execute(
-            "INSERT INTO tasks (id, title, priority) VALUES ($1,$2,$3);", [id, title, priority]
+            "INSERT INTO tasks (id, title, priority) VALUES ($1, $2, $3);", [id, title, priority]
         )
 
     def get_tasks_by_priority(self, priority: str) -> list[GetTasksByPriorityRow]:
         rows = self._conn.execute(
-            "SELECT id, title, priority FROM tasks WHERE priority =$1;", [priority]
+            "SELECT id, title, priority FROM tasks WHERE priority = $1;", [priority]
         ).fetchall()
         return [GetTasksByPriorityRow(id=row[0], title=row[1], priority=row[2]) for row in rows]
 
     def get_tasks_by_priority_raw(self, priority: str) -> list[tuple[Any, ...]]:
         return self._conn.execute(
-            "SELECT id, title, priority FROM tasks WHERE priority =$1;", [priority]
+            "SELECT id, title, priority FROM tasks WHERE priority = $1;", [priority]
         ).fetchall()
 
     def get_all_tasks(self) -> list[GetAllTasksRow]:

--- a/sqg/tests/__snapshots__/test_postgres_source.py.snapshot
+++ b/sqg/tests/__snapshots__/test_postgres_source.py.snapshot
@@ -73,7 +73,7 @@ class TestPostgresSource:
 
     def get_order(self, id: int) -> GetOrderRow | None:
         row = self._conn.execute(
-            "select id, customer, total, created_at from prod.public.orders where id =$1;", [id]
+            "select id, customer, total, created_at from prod.public.orders where id = $1;", [id]
         ).fetchone()
         if row is None:
             return None
@@ -81,7 +81,7 @@ class TestPostgresSource:
 
     def get_order_raw(self, id: int) -> tuple[Any, ...] | None:
         return self._conn.execute(
-            "select id, customer, total, created_at from prod.public.orders where id =$1;", [id]
+            "select id, customer, total, created_at from prod.public.orders where id = $1;", [id]
         ).fetchone()
 
     def list_orders(self) -> list[ListOrdersRow]:

--- a/sqg/tests/__snapshots__/test_sources.py.snapshot
+++ b/sqg/tests/__snapshots__/test_sources.py.snapshot
@@ -70,7 +70,7 @@ class TestSources:
 
     def attach(self, sources_users: str) -> None:
         self._conn.execute(
-            f"""attach '{sources_users}' as "users" (TYPE SQLITE);""", []
+            f"""attach  '{sources_users}' as "users" (TYPE SQLITE);""", []
         )
 
     def test_2(self) -> list[Test2Row]:

--- a/sqg/tests/__snapshots__/test_sqlite.py.snapshot
+++ b/sqg/tests/__snapshots__/test_sqlite.py.snapshot
@@ -280,7 +280,7 @@ select 10 count, email from users where id = '1';""", ()
 
     def users_6(self, name: str) -> Users6Row | None:
         row = self._conn.execute(
-            "SELECT * FROM users WHERE name =?", (name, )
+            "SELECT * FROM users WHERE name = ?", (name, )
         ).fetchone()
         if row is None:
             return None
@@ -288,18 +288,18 @@ select 10 count, email from users where id = '1';""", ()
 
     def users_6_raw(self, name: str) -> tuple[Any, ...] | None:
         return self._conn.execute(
-            "SELECT * FROM users WHERE name =?", (name, )
+            "SELECT * FROM users WHERE name = ?", (name, )
         ).fetchone()
 
     def users_7(self, name: str) -> list[Users7Row]:
         rows = self._conn.execute(
-            "SELECT * FROM users WHERE name =?", (name, )
+            "SELECT * FROM users WHERE name = ?", (name, )
         ).fetchall()
         return [Users7Row(id=row[0], name=row[1], email=row[2]) for row in rows]
 
     def users_7_raw(self, name: str) -> list[tuple[Any, ...]]:
         return self._conn.execute(
-            "SELECT * FROM users WHERE name =?", (name, )
+            "SELECT * FROM users WHERE name = ?", (name, )
         ).fetchall()
 
     def reserved_word_test(self) -> ReservedWordTestRow | None:

--- a/sqg/tests/__snapshots__/turso-test-sqlite.ts.snapshot
+++ b/sqg/tests/__snapshots__/turso-test-sqlite.ts.snapshot
@@ -213,7 +213,7 @@ export class TestSqlite {
   ): Promise<{ id: string; name: string; email: string } | undefined> {
     const stmt = await this.prepare(
       "users6",
-      "SELECT * FROM users WHERE name =?",
+      "SELECT * FROM users WHERE name = ?",
     );
     return (await stmt.get(name)) as
       | { id: string; name: string; email: string }
@@ -224,7 +224,7 @@ export class TestSqlite {
   ): Promise<{ id: string; name: string; email: string | null }[]> {
     const stmt = await this.prepare(
       "users7",
-      "SELECT * FROM users WHERE name =?",
+      "SELECT * FROM users WHERE name = ?",
     );
     return (await stmt.all(name)) as {
       id: string;

--- a/sqg/tests/foreign-keys.test.ts
+++ b/sqg/tests/foreign-keys.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { processProject } from "../src/sqltool";
+
+// Introspection executes every EXEC against a database with no data, so a
+// NOT NULL foreign key cannot be satisfied — the parent row does not exist and
+// statements do not share a transaction. Generation must not fail over it.
+// https://github.com/sqg-dev/sqg/issues/10
+describe("foreign keys during introspection", () => {
+  it("generates for sqlite despite an unsatisfiable foreign key", async () => {
+    const files = await processProject("tests/test-fk-sqlite.yaml");
+    expect(files).toHaveLength(1);
+    const generated = readFileSync(files[0], "utf-8");
+    expect(generated).toContain("insertPost");
+    expect(generated).toContain("limit ?");
+  });
+
+  it("generates for duckdb despite an unsatisfiable foreign key", async () => {
+    const files = await processProject("tests/test-fk-duckdb.yaml");
+    expect(files).toHaveLength(1);
+    expect(readFileSync(files[0], "utf-8")).toContain("insertPost");
+  });
+
+  // Relaxing the constraints must not reach the fixtures: TESTDATA describes
+  // real data, so a foreign key it violates is a mistake worth reporting.
+  it("still rejects a foreign key violation in TESTDATA", async () => {
+    await expect(processProject("tests/test-fk-testdata.yaml")).rejects.toThrow(
+      /FOREIGN KEY constraint failed/,
+    );
+  });
+});

--- a/sqg/tests/placeholder-spacing.test.ts
+++ b/sqg/tests/placeholder-spacing.test.ts
@@ -1,0 +1,85 @@
+import { unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseSQLQueries } from "../src/sql-query";
+
+function parseSQL(content: string) {
+  const tmpPath = join(
+    tmpdir(),
+    `sqg-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sql`,
+  );
+  writeFileSync(tmpPath, content);
+  try {
+    return parseSQLQueries(tmpPath, []);
+  } finally {
+    unlinkSync(tmpPath);
+  }
+}
+
+describe("placeholder spacing", () => {
+  // `LIMIT ${n}` used to render as `LIMIT$1`, which Postgres lexes as the
+  // identifier `limit$1` instead of a placeholder. https://github.com/sqg-dev/sqg/issues/10
+  it("keeps the whitespace in front of a variable", () => {
+    const query = parseSQL(`-- QUERY paged
+@set lim = 10
+SELECT * FROM users LIMIT \${lim};
+`).queries[0];
+
+    expect(query.queryPositional.sql).toBe("SELECT * FROM users LIMIT $1;");
+    expect(query.queryNamed.sql).toBe("SELECT * FROM users LIMIT $lim;");
+    expect(query.queryAnonymous.sql).toBe("SELECT * FROM users LIMIT ?;");
+  });
+
+  it("separates a placeholder from a preceding keyword even without whitespace", () => {
+    const query = parseSQL(`-- QUERY paged
+@set lim = 10
+SELECT * FROM users LIMIT\${lim};
+`).queries[0];
+
+    expect(query.queryPositional.sql).toBe("SELECT * FROM users LIMIT $1;");
+    expect(query.queryAnonymous.sql).toBe("SELECT * FROM users LIMIT ?;");
+  });
+
+  it("does not add whitespace after operators or punctuation", () => {
+    const query = parseSQL(`-- QUERY find
+@set name = 'bob'
+@set lim = 10
+SELECT * FROM users WHERE name=\${name} AND rank>\${lim};
+`).queries[0];
+
+    expect(query.queryPositional.sql).toBe("SELECT * FROM users WHERE name=$1 AND rank>$2;");
+  });
+
+  // sqlParts feeds the template-literal renderers (TS/Java), so it has to carry
+  // the same spacing as the joined `sql` string.
+  it("keeps sqlParts and the joined sql in sync", () => {
+    const query = parseSQL(`-- QUERY paged
+@set lim = 10
+@set off = 0
+SELECT * FROM users LIMIT \${lim} OFFSET \${off};
+`).queries[0];
+
+    expect(query.queryPositional.sqlParts).toEqual([
+      "SELECT * FROM users LIMIT ",
+      "$1",
+      " OFFSET ",
+      "$2",
+      ";",
+    ]);
+    expect(query.queryAnonymous.sqlParts).toEqual([
+      "SELECT * FROM users LIMIT ",
+      "?",
+      " OFFSET ",
+      "?",
+      ";",
+    ]);
+    expect(query.queryNamed.sqlParts).toEqual([
+      "SELECT * FROM users LIMIT ",
+      "$lim",
+      " OFFSET ",
+      "$off",
+      ";",
+    ]);
+  });
+});

--- a/sqg/tests/sqltool-pg.test.ts
+++ b/sqg/tests/sqltool-pg.test.ts
@@ -27,6 +27,20 @@ describe("sqg-pg", () => {
     }, 30_000); // 30 second timeout for test execution
   });
 
+  describe("foreign keys during introspection", () => {
+    // The temp database holds no data, so `insert into posts` can never satisfy
+    // its NOT NULL foreign key. https://github.com/sqg-dev/sqg/issues/10
+    it("generates despite an unsatisfiable foreign key", async () => {
+      const files = await processProject("tests/test-fk-pg.yaml");
+      expect(files).toHaveLength(1);
+      const generated = readFileSync(files[0], "utf-8");
+      expect(generated).toContain("insert_post");
+      // `limit ${lim}` must keep its space — glued to the keyword, Postgres
+      // lexes the placeholder as part of an identifier.
+      expect(generated).toContain("limit %s");
+    }, 30_000);
+  });
+
   describe("parameter type introspection", () => {
     it("should infer BIGINT parameter type from column, not from literal value", async () => {
       const filePath = resolve("tests/test-pg.sql");

--- a/sqg/tests/test-fk-duckdb.yaml
+++ b/sqg/tests/test-fk-duckdb.yaml
@@ -1,0 +1,10 @@
+version: 1
+
+name: test-fk-duckdb
+
+sql:
+  - files:
+      - test-fk.sql
+    gen:
+      - generator: typescript/duckdb
+        output: /tmp/fk-duckdb/

--- a/sqg/tests/test-fk-pg.yaml
+++ b/sqg/tests/test-fk-pg.yaml
@@ -1,0 +1,10 @@
+version: 1
+
+name: test-fk-pg
+
+sql:
+  - files:
+      - test-fk.sql
+    gen:
+      - generator: python/postgres
+        output: /tmp/fk-pg/

--- a/sqg/tests/test-fk-sqlite.yaml
+++ b/sqg/tests/test-fk-sqlite.yaml
@@ -1,0 +1,10 @@
+version: 1
+
+name: test-fk-sqlite
+
+sql:
+  - files:
+      - test-fk.sql
+    gen:
+      - generator: typescript/sqlite
+        output: /tmp/fk-sqlite/

--- a/sqg/tests/test-fk-testdata.sql
+++ b/sqg/tests/test-fk-testdata.sql
@@ -1,0 +1,18 @@
+-- MIGRATE 1
+create table authors (
+    id integer primary key,
+    name text not null
+);
+
+-- MIGRATE 2
+create table posts (
+    id integer primary key,
+    author_id integer not null references authors(id),
+    title text not null
+);
+
+-- TESTDATA seed
+insert into posts (id, author_id, title) values (1, 999, 'orphan');
+
+-- QUERY allPosts
+select id, title from posts;

--- a/sqg/tests/test-fk-testdata.yaml
+++ b/sqg/tests/test-fk-testdata.yaml
@@ -1,0 +1,10 @@
+version: 1
+
+name: test-fk-testdata
+
+sql:
+  - files:
+      - test-fk-testdata.sql
+    gen:
+      - generator: typescript/sqlite
+        output: /tmp/fk-testdata/

--- a/sqg/tests/test-fk.sql
+++ b/sqg/tests/test-fk.sql
@@ -1,0 +1,26 @@
+-- Schema with a NOT NULL foreign key: introspection runs every statement
+-- against an empty database, so the parent row referenced by insertPost can
+-- never exist. Generation must still succeed.
+-- MIGRATE 1
+create table authors (
+    id integer primary key,
+    name text not null
+);
+
+-- MIGRATE 2
+create table posts (
+    id integer primary key,
+    author_id integer not null references authors(id),
+    title text not null
+);
+
+-- EXEC insertPost
+@set id = 1
+@set author_id = 42
+@set title = 'hello'
+insert into posts (id, author_id, title) values (${id}, ${author_id}, ${title});
+
+-- QUERY postsByAuthor
+@set author_id = 42
+@set lim = 10
+select id, title from posts where author_id = ${author_id} limit ${lim};

--- a/website/src/content/docs/guides/faq.mdx
+++ b/website/src/content/docs/guides/faq.mdx
@@ -363,6 +363,30 @@ INSERT INTO users (id, name) VALUES (1, 'Test');
 INSERT INTO posts (id, user_id, title) VALUES (1, 1, 'Test Post');
 ```
 
+### Constraint violations during introspection
+
+SQG runs every `QUERY` and `EXEC` against a throwaway database to introspect
+types, each in its own transaction — so an `INSERT` with a NOT NULL foreign key
+has no parent row to reference unless a TESTDATA block created it.
+
+You do not need to drop or defer those constraints. Once MIGRATE and TESTDATA
+have run, SQG stops enforcing referential integrity (SQLite and PostgreSQL), and
+where the engine cannot disable it (DuckDB), a constraint violation in an `EXEC`
+is reported as a warning instead of failing generation — nothing in the
+generated code depends on the statement actually running.
+
+Your fixtures are still checked: a foreign key violated by a MIGRATE or TESTDATA
+block is an error, because those describe real data.
+
+A `QUERY` also still has to execute, because its result shape is what SQG
+introspects. If an `INSERT ... RETURNING` query hits a constraint, add a
+TESTDATA block that inserts the rows it depends on:
+
+```sql
+-- TESTDATA
+INSERT INTO users (id, name) VALUES (1, 'Test');
+```
+
 ### Type inference seems wrong
 
 Check that:


### PR DESCRIPTION
Fixes #10 — two gotchas reported by @mathijs81.

## `LIMIT ${param}` generated `LIMIT$1`

Postgres lexes `LIMIT$1` as the identifier `limit$1` and rejects the query.

Root cause: when the parser reached a `${var}` node it sliced the preceding SQL up to the *end of the last token* instead of up to the *start of the variable*, dropping the whitespace in front of the placeholder. Whitespace *after* a variable was kept — that asymmetry is why only the leading side broke.

Placeholders now go through `pushPlaceholder()`, which separates a placeholder from a preceding word character in all three rendering paths. This replaces the old fix-up that patched only the joined `sql` string, leaving it inconsistent with `sqlParts` (what the TS/Java template-literal renderers emit).

One existing snapshot already contained `select 1 as n where$1 ::int is null`, so the bug was baked into the test corpus.

## Unsatisfiable foreign keys during introspection

Each `QUERY`/`EXEC` is introspected in its own transaction, so an `INSERT` with a NOT NULL foreign key can never be satisfied — the reporter worked around it with `DEFERRABLE INITIALLY DEFERRED`.

After initialization, referential integrity is no longer enforced:

| Engine | Mechanism |
|---|---|
| SQLite | `PRAGMA foreign_keys = OFF` (better-sqlite3 turns it **on** by default) |
| PostgreSQL | `session_replication_role = replica` — best effort, needs superuser; `SET LOCAL` behind a savepoint in external-`url:` mode |
| DuckDB | no such switch, so a constraint violation in an `EXEC` warns instead of failing |

Tolerating an `EXEC` failure is safe because nothing in the generated code depends on it running — parameter types come from the prepared statement. A `QUERY` (including `INSERT ... RETURNING`) still executes and still fails, since its result shape is what gets introspected.

**Fixtures stay checked.** The relaxation starts *after* BASELINE/MIGRATE/TESTDATA, so a foreign key violated by a fixture is still an error — that data is real and a broken reference in it is worth reporting. The alternative, requiring TESTDATA to satisfy every `EXEC`, would couple fixture primary keys to each query's `@set` literals (`@set author_id = 42` demands an author with `id = 42`) and gets unworkable with self-referencing, composite, or multi-level FK chains.

## Tests

- `placeholder-spacing.test.ts` — spacing across all three renderings, `sqlParts`/`sql` consistency, no spurious space after operators
- `foreign-keys.test.ts` — SQLite and DuckDB generate despite an unsatisfiable FK, **and** a FK violation in TESTDATA still throws
- `sqltool-pg.test.ts` — same for Postgres against the testcontainer

22 snapshots updated; `git diff -w` over them is empty, i.e. whitespace restoration only (`priority =$1` → `priority = $1`, `VALUES (?,?,?)` → `VALUES (?, ?, ?)`).

Verified: vitest 210 passed, `just test-java` BUILD SUCCESSFUL, `just test-python` 54 passed, `pnpm build` clean, biome unchanged from baseline (13 warnings / 2 infos before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)